### PR TITLE
feat(neotree): `+neotree/refresh` to keep neotree in sync on buffer switches

### DIFF
--- a/modules/ui/neotree/README.org
+++ b/modules/ui/neotree/README.org
@@ -40,10 +40,14 @@ NERDTree.
  󱌣 This module has no usage documentation yet. [[doom-contrib-module:][Write some?]]
 #+end_quote
 
-* TODO Configuration
-#+begin_quote
- 󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
-#+end_quote
+* Configuration
+** Keeping neotree synchronized
+To keep neotree up to date whenever you switch to another buffer or project,
+add or integrate the following snippet to your =config.el=:
+#+begin_src elisp
+(after! neotree
+  (add-hook 'doom-switch-buffer-hook #'+neotree/refresh))
+#+end_src
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]

--- a/modules/ui/neotree/autoload.el
+++ b/modules/ui/neotree/autoload.el
@@ -68,3 +68,32 @@
              (neo-point-auto-indent)))
           (t
            (call-interactively #'neotree-enter)))))
+
+;;;###autoload
+(defun +neotree/refresh ()
+  "Refresh neotree to show the current file's project if
+  neotree is open, the current buffer belongs to a file,
+  that file belongs to a project, and neotree is not
+  already showing that project."
+ (interactive)
+ (let* ((cur-buffer      (current-buffer))
+        (cur-buffer-file (buffer-file-name cur-buffer)))
+   ;; We refresh neotree only when all of the following conditions are met.
+   ;; 1. The current buffer belongs to a file. This condition avoids updates
+   ;;    when switching to buffers such as *doom* or *scratch*.
+   ;; 2. Neotree is open.
+   ;; 3. The current buffer is in a project that neotree can show.
+   ;; 4. Neotree is not already showing that buffer's project.
+   (when (and cur-buffer-file
+              (neo-global--window-exists-p)
+              (projectile-project-root)
+              (not (neo-global--file-in-root-p cur-buffer-file)))
+     ;; Refresh neotree by:
+     ;; 1. Explicitly changing the directory to the current project root because
+     ;;    neotree sometimes picks the wrong root (e.g., chooses a subdirectory).
+     (neotree-dir (doom-project-root))
+     ;; 2. Opening our current file in neotree. This is the actual refresh.
+     (+neotree/find-this-file)
+     ;; 3. Focusing the current buffer because +neotree/find-this-file switches
+     ;;    focus to the neotree window.
+     (select-window (get-buffer-window cur-buffer)))))


### PR DESCRIPTION
This PR adds the new `+neotree/refresh` function that refreshes neotree to show the current buffer's file. By adding the following snippet to your `config.el` to run the refresh on every buffer switch, neotree is always up to date:

```elisp
(after! neotree
  (add-hook 'doom-switch-buffer-hook #'+neotree/refresh))
```

The following screencast demonstrates the automatic synchonization by switching between buffers. Note that we do not refresh neotree when we visit a buffer that does not correspond to a file, such as `*Messages*` and `*doom*`.

[Screencast From 2026-02-08 17-49-04.webm](https://github.com/user-attachments/assets/3b46e2c0-3af9-4e96-babc-dcefcd218a65)

For now, the automatic synchronization of neotree is not enabled by default to not break existing behavior. Instead, I documented how to enable it in `modules/ui/neotree/README.org`.

(The commit messages are missing their scope `(neotree)` because the commit linter says it is an invalid scope. I'd be happy to change the commit messages if requested.)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work. (I drafted a first version of this code with ChatGPT. None of that code survived but it pushed me into the right direction.)
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
