### PR TITLE
fix(lib): don't clobber debug vars without a stashed value

### DIFF
--- a/lisp/lib/debug.el
+++ b/lisp/lib/debug.el
@@ -24,7 +24,7 @@
 (progn
   (cl-defun set-debug-var! (var &optional (debug-val t) (level 1))
     "Set VAR to DEBUG-VAL (or `t') when `doom-debug-mode' is active at >=LEVEL."
-    (setf (alist-get var doom-debug--variables) (cons debug-val level))))
+    (setf (alist-get var doom-debug--variables) (list debug-val level))))
 
 (defvar doom-debug--unbound-variables nil)
 
@@ -34,22 +34,31 @@
     (mapc #'doom-debug--set-var vars)))
 
 (defun doom-debug--set-var (spec)
-  (cond ((listp spec)
+  (cond ((consp spec)
          (pcase-let ((`(,var ,val ,level) spec))
-           (if (boundp var)
-               (set-default-toplevel-value
-                var (if (or (not doom-debug-mode)
-                            (> (or level 1) doom-log-level))
-                        (prog1 (get var 'initial-value)
-                          (put var 'initial-value nil))
-                      (doom-log 3 "debug:vars: %s = %S" var val)
-                      (put var 'initial-value (default-toplevel-value var))
-                      val))
-             (add-to-list 'doom-debug--unbound-variables spec))))
+           (cond ((null var))
+                 ((boundp var)
+                  (if (or (not doom-debug-mode)
+                          (> (or level 1) doom-log-level))
+                      ;; Restore the variable only if we set it earlier; the
+                      ;; stash is absent for variables registered after
+                      ;; `doom-debug-mode' was last enabled.
+                      (when-let* ((stash (get var 'doom-debug--initial-value)))
+                        (put var 'doom-debug--initial-value nil)
+                        (set-default-toplevel-value var (car stash)))
+                    (doom-log 3 "debug:vars: %s = %S" var val)
+                    ;; Don't restash on repeat calls, or the debug value would
+                    ;; overwrite the user's original value.
+                    (unless (get var 'doom-debug--initial-value)
+                      (put var 'doom-debug--initial-value
+                           (list (default-toplevel-value var))))
+                    (set-default-toplevel-value var val)))
+                 ((add-to-list 'doom-debug--unbound-variables spec)))))
+        ((null spec))
         ((boundp spec)
          (doom-log 3 "debug:vars: %s = %S" spec doom-debug-mode)
          (set-default-toplevel-value spec doom-debug-mode))
-        ((add-to-list 'doom-debug--unbound-variables (cons spec t)))))
+        ((add-to-list 'doom-debug--unbound-variables (list spec t)))))
 
 (defun doom-debug--timestamped-message-a (format-string &rest _args)
   "Advice to run before `message' that prepends a timestamp to each message."


### PR DESCRIPTION
## What

`doom-debug--set-var` restores a registered variable from its `initial-value` symbol property. That property is nil unless a previous activation stashed a value, so the restore path writes nil into user variables in two situations:

1. Enabling `doom-debug-mode` while `doom-log-level` is 0 (the default without `--debug-init`): every leveled spec fails the `(> level doom-log-level)` check and takes the restore path during the enable itself, setting every registered variable to nil.
2. Disabling `doom-debug-mode` nils every variable registered via `set-debug-var!` after the mode was enabled, because the enable-time sweep ran before the entry existed and never stashed anything.

For most registered variables nil equals their normal default, so the damage is invisible. `yas-verbosity` (registered by `:editor snippets` with `(set-debug-var! 'yas-verbosity 3)`, normal value 2) is not one of them; once nil'd, the first `emacs-lisp-mode` buffer crashes:

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  yas--message(4 "Loading for `%s', just-in-time: %s!" emacs-lisp-mode ...)
  yas--load-pending-jits()
  yas-minor-mode(1)
  yas-minor-mode-on()
  yas-global-mode-enable-in-buffer()
```

Reproduce: start Emacs without `--debug-init`, `M-x doom-debug-mode`, open any elisp file.

## How

- Stash the original value wrapped in a list under a dedicated `doom-debug--initial-value` property and restore only when the stash exists. A nil original and a never-stashed variable are now distinguishable, which removes both nil-writing paths.
- Don't restash on repeat calls, so toggling twice cannot overwrite the stashed original with the debug value.
- `set-debug-var!` stored `(cons debug-val level)`, an improper list whose level slot `pcase-let` destructures to nil, silently treating every LEVEL as 1. Store a proper list.
- Requeued bare-symbol specs were `(cons spec t)`; when the variable finally binds, the value slot destructures to nil and the variable is set to nil instead of t. Use `(list spec t)`.
- Skip nil variables and nil specs instead of raising `(setting-constant nil)` from `set-default-toplevel-value`.

Tested with an ERT suite covering: enable at log level 0 leaves an unstashed variable untouched, disable after late registration restores nothing, enable/disable roundtrips preserve nil and non-nil originals, re-enable preserves the original stash, `set-debug-var!` honors LEVEL, a requeued bare symbol is set to t once bound, and nil specs do not signal. All six previously-failing cases pass after the change; the two roundtrip cases pass before and after.