### PR TITLE
fix(lib): strip text properties in doom-region by default

### DIFF
--- a/lisp/lib/text.el
+++ b/lisp/lib/text.el
@@ -152,12 +152,14 @@ selected, returns (nil . nil)."
 (defun doom-region (&optional preserve-properties?)
   "Return the contents of the active selection.
 
+Text properties are stripped, unless PRESERVE-PROPERTIES? is non-nil.
+
 Return nil if nothing is selected."
   (when (doom-region-active-p)
     (let* ((bounds (doom-region-bounds)))
       (if preserve-properties?
-          (buffer-substring-no-properties (car bounds) (cdr bounds))
-        (buffer-substring (car bounds) (cdr bounds))))))
+          (buffer-substring (car bounds) (cdr bounds))
+        (buffer-substring-no-properties (car bounds) (cdr bounds))))))
 
 ;;;###autoload
 (defun doom-thing-at-point-or-region (&optional thing prompt)


### PR DESCRIPTION
## Problem

`doom-region`'s two branches are swapped, `lisp/lib/text.el:152`:

```elisp
(if preserve-properties?
    (buffer-substring-no-properties (car bounds) (cdr bounds))
  (buffer-substring (car bounds) (cdr bounds)))
```

Calling `(doom-region)` returns propertized text, and `(doom-region t)` strips the properties. That is the opposite of the argument name.

## Why it matters

Propertized region text breaks callers that feed the selection back into the minibuffer. `+vertico-file-search` seeds the search query with `(regexp-quote (doom-region))`, `modules/completion/vertico/autoload/vertico.el:26`.

Select text in a buffer whose content carries a `read-only` text property with `read-only` in `front-sticky`, then run `+default/search-project`. The query is inserted into the minibuffer with its `read-only` property intact. Consult's perl async split style then inserts `#` at `minibuffer-prompt-end` during minibuffer setup, which signals `text-read-only` and aborts the search.

The reported error is a different one, because consult's `unwind-protect` sends `destroy` down an async pipeline whose indicator overlay was never created:

```
Debugger entered--Lisp error: (wrong-type-argument overlayp nil)
  delete-overlay(nil)
  ...
  consult--with-async-f(...)
  consult--read-1(...)
  consult--grep("Search" consult--ripgrep-make-builder "/path/to/project/" #("query" 0 5 (... read-only t front-sticky (read-only) ...)))
  +vertico-file-search(:query nil :in nil :all-files nil)
  +vertico/project-search(nil)
  +default/search-project(nil)
```

Minimal reproduction of the failing step, independent of consult:

```elisp
(minibuffer-with-setup-hook
    (:append (lambda ()
               (save-excursion
                 (goto-char (minibuffer-prompt-end))
                 (insert-before-markers "#"))))
  (read-from-minibuffer "Search: " (propertize "query" 'read-only t 'front-sticky '(read-only))))
;; => (text-read-only)
```

## Fix

Swap the branches so the default strips properties, and document it.

No caller depends on the current behaviour. `+eval/send-region-to-repl` (`modules/tools/eval/autoload/repl.el:178,190`) wants plain text. `+format/org-blocks-in-region` (`modules/editor/format/autoload/org.el:33`) passes `t`, but its `(interactive (doom-region t))` is broken either way: it needs `(BEG END)` from `doom-region-bounds`, not a string. That is a separate issue.

## Verification

Ad-hoc ERT against the patched `text.el`, run in a live Emacs 30.2.50, three tests: default strips properties, `t` preserves them, no selection returns nil. The first two fail before the patch, all three pass after.

End to end, with the patch loaded, `(regexp-quote (doom-region))` over a `read-only`/`front-sticky` selection returns a propertyless string, and the minibuffer setup insert above succeeds instead of signalling `text-read-only`.