### PR TITLE
fix(lib): don't double use doom-font-increment

### DIFF
--- a/lisp/lib/fonts.el
+++ b/lisp/lib/fonts.el
@@ -93,7 +93,7 @@ Doesn't work in terminal Emacs."
                               remap-xlfd
                             (purecopy font))
                           (error "Could not decompose %s font" var))))
-                (let* ((step      (if fixed-size-p 0 (* increment doom-font-increment)))
+                (let* ((step      (if fixed-size-p 0 increment))
                        (orig-size (font-get font :size))
                        (new-size  (if fixed-size-p increment (+ orig-size step))))
                   (cond ((<= new-size 0)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->
`doom/increase-font-size` and `doom/decrease-font-size` already passes multiples of `doom-font-increment` to `doom-adjust-font-size`. Multiplying this parameter by `doom-font-increment` makes the increment becomes square of `doom-font-increment`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
