### PR TITLE
fix: abbreviate paths added to trusted-content

### DIFF
--- a/lisp/doom-emacs.el
+++ b/lisp/doom-emacs.el
@@ -382,8 +382,8 @@ Otherwise, `en/disable-command' (in novice.el.gz) is hardcoded to write them to
 ;; Trust the contents of $EMACSDIR and $DOOMDIR, because the user will likely be
 ;; working with either/both.
 (when (boundp 'trusted-content)
-  (add-to-list 'trusted-content (file-truename doom-emacs-dir))
-  (add-to-list 'trusted-content (file-truename doom-user-dir)))
+  (add-to-list 'trusted-content (abbreviate-file-name (file-truename doom-emacs-dir)))
+  (add-to-list 'trusted-content (abbreviate-file-name (file-truename doom-user-dir))))
 
 ;; Ensure .dir-locals.el in $EMACSDIR and $DOOMDIR are always respected
 (add-to-list 'safe-local-variable-directories doom-emacs-dir)


### PR DESCRIPTION
According to the docstring of `trusted-content`, entries are required to be _abbreviated_:

> Each element of the list should be a string naming a file or a directory
> by their abbreviated file names:
> [...]
> For example, an entry "~/mycode/" means that Emacs will trust all the
> files in the directory "mycode" under your home directory.

The current config which adds the `file-truename` of `doom-emacs-dir` and `doom-user-dir` turns out to be a no-op, since `trusted-content-p` abbreviates only the buffer's filename before comparing against these entries, e.g. `"~/.doom.d/config.el"` is considered untrusted since it's not a prefix of the entry `"/home/user/.doom.d/"`
(I did find this slightly strange but the impl seems to have been around unchanged since Emacs-30.1 / 2024)

Found this out due to linting suddenly being disabled across all my elisp files - Flycheck added a `trusted-content-p` guard to the emacs-lisp checker earlier this year (flycheck/flycheck#2160).

(Side note: the link to https://doomemacs.org/d/git-conventions below is broken, couldn't check if my commit conforms)
 
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.