### PR TITLE
fix: follow dir symlinks in projectile file lists

### DIFF
--- a/modules/doom/compat/+projectile.el
+++ b/modules/doom/compat/+projectile.el
@@ -153,7 +153,7 @@ And if it's a function, evaluate it."
   (put 'projectile-git-submodule-command 'initial-value projectile-git-submodule-command)
   (setq projectile-git-submodule-command nil
         ;; Include and follow symlinks in file listings.
-        projectile-git-fd-args (concat "-tl " projectile-git-fd-args)
+        projectile-git-fd-args (concat "-L -tl " projectile-git-fd-args)
         projectile-indexing-method 'hybrid
         projectile-generic-command
         (lambda (_)


### PR DESCRIPTION
-tl includes symlink nodes in fd's results. It does not follow them. The nearby comment claims both. Directory-symlink farms then contribute only the symlink paths, not the files inside.

Pass -L as well so fd walks those directories. The same file will appear once per alias.

Made with [Cursor](https://cursor.com)