### PR TITLE
fix(:doom): gcmh settings never applied

### DIFF
--- a/modules/doom/init.el
+++ b/modules/doom/init.el
@@ -20,7 +20,7 @@
 ;; when it's idle. However, if the idle delay is too long, we run the risk of
 ;; runaway memory usage in busy sessions. And if it's too low, then we may as
 ;; well not be using gcmh at all.
-(use-package! gcmh-mode
+(use-package! gcmh
   :unless (fboundp 'igc-info)
   :hook (doom-first-buffer . gcmh-mode)
   :config


### PR DESCRIPTION
The gcmh package hasn't been loading since 1123dc57934d when it was moved to `use-package`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
