### PR TITLE
fix(cli): call doom-version in doctor

### DIFF
--- a/bin/doom-doctor
+++ b/bin/doom-doctor
@@ -221,7 +221,7 @@ in."
         (doom-startup)
         (require 'straight)
 
-        (print! (success "Initialized Doom Emacs %s") doom-version)
+        (print! (success "Initialized Doom Emacs %s") (doom-version))
         (print!
          (if (hash-table-p doom-modules)
              (success "Detected %d modules" (hash-table-count doom-modules))


### PR DESCRIPTION
## Summary

Call `doom-version` as a function in `doom doctor`.

Commit 0247fb5e6 replaced the `doom-version` variable with a function, but the doctor still reads it as a variable. This causes `doom doctor` to abort with `void-variable doom-version`.

## Testing

- Ran `doom doctor` with Doom 2.2.4 and Emacs 31.1
- Confirmed the doctor completes successfully