### PR TITLE
fix(docs): render keyboard links

### DIFF
--- a/lisp/doom-docs.el
+++ b/lisp/doom-docs.el
@@ -825,10 +825,12 @@ This primes `org-mode' for reading."
            (propertize "Key sequence:" 'face 'bold)
            (doom-docs-link--kbd key t)))
 
-(defun doom-docs-link--kbd-activate-func (beg end key _bracketed?)
+(defun doom-docs-link--kbd-activate-func (beg end _path _bracketed?)
   (if (not org-descriptive-links)
       (remove-text-properties beg end '(display nil))
-    (let* ((keystr (doom-docs-link--kbd key))
+    (let* ((context (doom-docs-context-at-pos beg))
+           (key (doom-docs--get-link-description context))
+           (keystr (doom-docs-link--kbd key))
            (total (max 0 (- (string-width key)
                             (string-width keystr))))
            (keybeg (save-excursion


### PR DESCRIPTION
Commit cc989870709578d5aa4e4dedae8fd84c76a9b260 stopped getting `key` via `doom-docs-context-at-pos`, trusting the value of `key` passed in. But that value is the link's "path", which for `kbd:` links is the empty string: this causes the rest of the function to treat the entire link as the `kbd:` that needs to be hidden.

Restore these calls, and rename the function argument to make it more clear what it is (and that it should not be used).

Amend: cc989870709578d5aa4e4dedae8fd84c76a9b260

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
